### PR TITLE
Implement mobile layout responsiveness

### DIFF
--- a/src/components/CardInfo/CardInfo.module.css
+++ b/src/components/CardInfo/CardInfo.module.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: 50px;
   align-items: center;
+  width: 100%;
+  padding: 0 0 24px;
 }
 
 .card_list_wrapper {
@@ -10,6 +12,7 @@
   flex-direction: column;
   gap: 32px;
   max-width: 888px;
+  width: 100%;
 }
 
 .card_info {
@@ -20,6 +23,7 @@
   border-radius: 20px;
   border: 1px solid rgba(16, 24, 40, 0.2);
   background: #fff;
+  width: 100%;
 }
 
 .description {
@@ -160,4 +164,111 @@
   justify-content: center;
   height: 100%;
   width: 888px;
+}
+
+@media (max-width: 1024px) {
+  .card_info {
+    gap: 20px;
+  }
+
+  .card_img_wrapper {
+    width: 260px;
+    height: 280px;
+  }
+}
+
+@media (max-width: 900px) {
+  .card_info {
+    flex-direction: column;
+    align-items: center;
+    text-align: left;
+  }
+
+  .card_img_wrapper {
+    width: 100%;
+    height: auto;
+    max-height: 320px;
+  }
+
+  .card_img {
+    height: auto;
+    max-height: 320px;
+  }
+
+  .info,
+  .left_info,
+  .secondary_info {
+    width: 100%;
+  }
+
+  .info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .left_info {
+    justify-content: space-between;
+  }
+
+  .secondary_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .description {
+    max-width: 100%;
+  }
+
+  .show_btn,
+  .load_more_btn {
+    width: 100%;
+    max-width: none;
+  }
+
+  .no_camp_title_wrapper {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .card_wrapper {
+    padding: 0 0 16px;
+    gap: 40px;
+  }
+
+  .card_info {
+    padding: 20px;
+    gap: 16px;
+  }
+
+  .card_img_wrapper {
+    max-height: 260px;
+  }
+
+  .list_details {
+    justify-content: center;
+  }
+
+  .item_details {
+    width: calc(50% - 8px);
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .card_info {
+    padding: 16px;
+  }
+
+  .left_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .item_details {
+    width: 100%;
+  }
 }

--- a/src/components/Filter/Filter.jsx
+++ b/src/components/Filter/Filter.jsx
@@ -115,31 +115,33 @@ export const Filter = () => {
   };
 
   return (
-    <div className={styles.filter_container}>
-      <div className={styles.location_container}>
-        <label className={styles.location_label} htmlFor="location_input">
-          Location{' '}
-        </label>
-        <div className={styles.relative_container}>
-          <input
-            className={styles.location_input}
-            type="text"
-            id="location_input"
-            name="location"
-            placeholder="Location"
-            required
-            onBlur={handleBlur}
-            onFocus={handleFocus}
-            onChange={(e) => setCityFilter(e.target.value)}
-          />
-          <img
-            className={styles.location_icon_disabled}
-            src={isInputFocused || inputValue ? location_icon : location_disabled_icon}
-            alt="location_icon"
-          />
+    <aside className={styles.filter_container}>
+      <div className={styles.section}>
+        <div className={styles.location_container}>
+          <label className={styles.location_label} htmlFor="location_input">
+            Location{' '}
+          </label>
+          <div className={styles.relative_container}>
+            <input
+              className={styles.location_input}
+              type="text"
+              id="location_input"
+              name="location"
+              placeholder="Location"
+              required
+              onBlur={handleBlur}
+              onFocus={handleFocus}
+              onChange={(e) => setCityFilter(e.target.value)}
+            />
+            <img
+              className={styles.location_icon_disabled}
+              src={isInputFocused || inputValue ? location_icon : location_disabled_icon}
+              alt="location_icon"
+            />
+          </div>
         </div>
       </div>
-      <div>
+      <div className={styles.section}>
         <p className={styles.filters_title}>Filters</p>
         <div className={styles.filters_wrapper}>
           <div className={styles.equipment_wrapper}>
@@ -189,6 +191,6 @@ export const Filter = () => {
         </div>
       </div>
       <button onClick={filterCampers} className={styles.search_btn}>Search</button>
-    </div>
+    </aside>
   );
 };

--- a/src/components/Filter/Filter.module.css
+++ b/src/components/Filter/Filter.module.css
@@ -3,10 +3,21 @@
   flex-direction: column;
   gap: 32px;
   width: 360px;
+  padding: 32px 24px 40px;
+  border-radius: 20px;
+  border: 1px solid rgba(16, 24, 40, 0.08);
+  background: #ffffff;
+  box-shadow: 0 20px 60px rgba(29, 30, 37, 0.08);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .search_btn {
-  width: 175px;
+  width: 100%;
   padding: 16px 60px;
   color: #f7f7f7;
   font-weight: 500;
@@ -15,7 +26,6 @@
   border-radius: 200px;
   background: #e44848;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
-  width: 100%;
 }
 
 .search_btn:hover {
@@ -40,8 +50,8 @@
 .location_container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  width: 360px;
+  gap: 12px;
+  width: 100%;
 }
 
 .location_label {
@@ -72,12 +82,13 @@
   color: #475467;
   font-weight: 500;
   line-height: 24px;
+  margin-bottom: 8px;
 }
 
 .filters_wrapper {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 40px;
 }
 
 .equipment_list {
@@ -114,14 +125,9 @@
   height: 33px;
 }
 
-.equipment_wrapper {
-  width: 360px;
-  margin-top: 14px;
-}
-
+.equipment_wrapper,
 .types_wrapper {
-  width: 360px;
-  margin-top: 14px;
+  width: 100%;
 }
 
 .types_list {
@@ -204,6 +210,7 @@
   .filter_container {
     width: 100%;
     max-width: 600px;
+    padding: 28px 24px 32px;
   }
 
   .location_container {
@@ -227,7 +234,7 @@
 
 @media (max-width: 600px) {
   .filter_container {
-    padding: 0;
+    padding: 24px 20px 28px;
   }
 
   .equipment_list {
@@ -248,6 +255,7 @@
 @media (max-width: 480px) {
   .filter_container {
     gap: 24px;
+    padding: 20px 16px 24px;
   }
 
   .equipment_list {

--- a/src/components/Filter/Filter.module.css
+++ b/src/components/Filter/Filter.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
+  width: 360px;
 }
 
 .search_btn {
@@ -186,4 +187,74 @@
 
 .equipment_list_item img {
   margin-bottom: 8px;
+}
+
+@media (max-width: 1200px) {
+  .filter_container {
+    width: 320px;
+  }
+
+  .equipment_wrapper,
+  .types_wrapper {
+    width: 100%;
+  }
+}
+
+@media (max-width: 900px) {
+  .filter_container {
+    width: 100%;
+    max-width: 600px;
+  }
+
+  .location_container {
+    width: 100%;
+  }
+
+  .equipment_wrapper,
+  .types_wrapper {
+    width: 100%;
+  }
+
+  .types_list {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .types_list_item {
+    flex: 1 1 140px;
+  }
+}
+
+@media (max-width: 600px) {
+  .filter_container {
+    padding: 0;
+  }
+
+  .equipment_list {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .types_list {
+    justify-content: center;
+    gap: 12px;
+  }
+
+  .types_list_item {
+    flex: 1 1 45%;
+    min-width: 140px;
+  }
+}
+
+@media (max-width: 480px) {
+  .filter_container {
+    gap: 24px;
+  }
+
+  .equipment_list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .types_list_item {
+    padding: 16px 20px;
+  }
 }

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -218,6 +218,96 @@
   margin-bottom: 14px;
 }
 
+@media (max-width: 1200px) {
+  .modal {
+    width: 90vw;
+    max-width: 900px;
+  }
+
+  .gallery_advert {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width: 900px) {
+  .modal {
+    width: 90vw;
+    max-width: 720px;
+    padding: 32px 28px;
+  }
+
+  .gallery_advert {
+    height: auto;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+  }
+
+  .photo_advert {
+    width: 48%;
+    min-width: 220px;
+    height: 200px;
+    border-radius: 12px;
+    object-fit: cover;
+  }
+
+  .tab {
+    flex-direction: column;
+  }
+
+  .left_container,
+  .right_container {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .modal {
+    width: calc(100vw - 32px);
+    margin: 20px auto;
+    padding: 24px 20px;
+  }
+
+  .name_wrapper {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nav_list {
+    gap: 24px;
+  }
+
+  .gallery_advert {
+    gap: 10px;
+  }
+
+  .photo_advert {
+    width: 100%;
+    height: 200px;
+  }
+
+  .tab {
+    gap: 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 20px 16px;
+  }
+
+  .nav_list {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .secondary_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}
+
 .form_textarea {
   padding-top: 18px;
   height: 114px;

--- a/src/components/NavList/NavList.jsx
+++ b/src/components/NavList/NavList.jsx
@@ -5,26 +5,42 @@ import styles from "./NavList.module.css";
 
 export const NavList = () => {
   return (
-  <div className={styles.nav_list_wrapper}>
-    <nav>
+    <div className={styles.nav_list_wrapper}>
+      <nav>
         <ul className={styles.navList}>
           <li className={styles.navItem}>
-            <NavLink to="/" exact="true" className={({ isActive }) => isActive ? styles.activeLink : styles.link}>
+            <NavLink
+              to="/"
+              end
+              className={({ isActive }) =>
+                isActive ? styles.activeLink : styles.link
+              }
+            >
               Home
             </NavLink>
           </li>
           <li className={styles.navItem}>
-            <NavLink to="/catalog" className={({ isActive }) => isActive ? styles.activeLink : styles.link}>
+            <NavLink
+              to="/catalog"
+              className={({ isActive }) =>
+                isActive ? styles.activeLink : styles.link
+              }
+            >
               Catalog
             </NavLink>
           </li>
           <li className={styles.navItem}>
-            <NavLink to="/favorites" className={({ isActive }) => isActive ? styles.activeLink : styles.link}>
+            <NavLink
+              to="/favorites"
+              className={({ isActive }) =>
+                isActive ? styles.activeLink : styles.link
+              }
+            >
               Favorites
             </NavLink>
           </li>
         </ul>
-    </nav>
-  </div> 
+      </nav>
+    </div>
   );
 };

--- a/src/components/NavList/NavList.module.css
+++ b/src/components/NavList/NavList.module.css
@@ -1,3 +1,10 @@
+.nav_list_wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 16px 32px;
+  background: #ffffff;
+}
+
 .navList {
   list-style: none;
   display: flex;
@@ -7,7 +14,7 @@
   font-weight: 500;
   gap: 60px;
   margin: 0;
-  padding: 20px 0 20px 20px;
+  padding: 8px 0;
 }
 
 .navItem {
@@ -33,4 +40,27 @@
 
 .navItem .activeLink {
   color: #e44848;
+}
+
+@media (max-width: 1024px) {
+  .nav_list_wrapper {
+    padding: 16px 24px;
+  }
+
+  .navList {
+    gap: 32px;
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav_list_wrapper {
+    padding: 12px 16px;
+  }
+
+  .navList {
+    flex-wrap: wrap;
+    gap: 16px;
+    font-size: 16px;
+  }
 }

--- a/src/pages/Catalog/Catalog.module.css
+++ b/src/pages/Catalog/Catalog.module.css
@@ -2,8 +2,9 @@
   display: flex;
   gap: 64px;
   justify-content: center;
-  margin-top: 24px;
-  margin-bottom: 24px;
+  align-items: flex-start;
+  margin: 32px auto 48px;
+  padding: 0 32px;
 }
 
 @media (max-width: 1200px) {

--- a/src/pages/Catalog/Catalog.module.css
+++ b/src/pages/Catalog/Catalog.module.css
@@ -5,3 +5,32 @@
   margin-top: 24px;
   margin-bottom: 24px;
 }
+
+@media (max-width: 1200px) {
+  .catalog_wrapper {
+    gap: 40px;
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .catalog_wrapper {
+    align-items: center;
+    gap: 32px;
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 900px) {
+  .catalog_wrapper {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0 24px 24px;
+  }
+}
+
+@media (max-width: 600px) {
+  .catalog_wrapper {
+    padding: 0 16px 24px;
+  }
+}

--- a/src/pages/Favorites/Favorites.module.css
+++ b/src/pages/Favorites/Favorites.module.css
@@ -4,6 +4,7 @@
   justify-content: center;
   margin-top: 24px;
   margin-bottom: 24px;
+  padding: 0 0 24px;
 }
 
 .cards_wrapper {
@@ -11,6 +12,7 @@
   flex-direction: column;
   gap: 50px;
   align-items: center;
+  width: 100%;
 }
 
 .card_list_wrapper {
@@ -18,6 +20,7 @@
   flex-direction: column;
   gap: 32px;
   max-width: 888px;
+  width: 100%;
 }
 
 .card_info {
@@ -28,6 +31,7 @@
   border-radius: 20px;
   border: 1px solid rgba(16, 24, 40, 0.2);
   background: #fff;
+  width: 100%;
 }
 
 .description {
@@ -165,4 +169,121 @@
 
 .empty_template_title {
   font-size: 30px;
+}
+
+@media (max-width: 1024px) {
+  .favorites_container {
+    gap: 40px;
+    padding: 0 24px 24px;
+  }
+
+  .card_info {
+    gap: 20px;
+  }
+
+  .card_img_wrapper {
+    width: 260px;
+    height: 280px;
+  }
+}
+
+@media (max-width: 900px) {
+  .favorites_container {
+    flex-direction: column;
+    align-items: center;
+    padding: 0 24px 24px;
+  }
+
+  .card_info {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .card_img_wrapper {
+    width: 100%;
+    height: auto;
+    max-height: 320px;
+  }
+
+  .card_img {
+    height: auto;
+  }
+
+  .info,
+  .left_info,
+  .secondary_info {
+    width: 100%;
+  }
+
+  .info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .left_info {
+    justify-content: space-between;
+  }
+
+  .secondary_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .description {
+    max-width: 100%;
+  }
+
+  .show_btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .favorites_container {
+    padding: 0 16px 24px;
+  }
+
+  .card_info {
+    padding: 20px;
+    gap: 16px;
+  }
+
+  .list_details {
+    justify-content: center;
+  }
+
+  .item_details {
+    width: calc(50% - 8px);
+    justify-content: center;
+  }
+
+  .empty_template {
+    position: static;
+    transform: none;
+    width: 100%;
+    padding: 40px 16px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .card_info {
+    padding: 16px;
+  }
+
+  .left_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .item_details {
+    width: 100%;
+  }
+
+  .empty_template_title {
+    font-size: 24px;
+  }
 }

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -8,8 +8,14 @@ const Home = () => {
   return (
     <div>
       <NavList/> 
-        <div className={styles.home_wrapper}> 
-          <img src={camper_img} alt="Campers" width="625" height="222"/>
+        <div className={styles.home_wrapper}>
+          <img
+            className={styles.hero_image}
+            src={camper_img}
+            alt="Campers"
+            width="625"
+            height="222"
+          />
           <div>
             <Link to="/catalog" className={styles.hero_btn}>
               Buy a camper

--- a/src/pages/HomePage/HomePage.module.css
+++ b/src/pages/HomePage/HomePage.module.css
@@ -5,6 +5,15 @@
   align-items: center;
   justify-content: center;
   margin: 24px 0;
+  padding: 0 24px;
+}
+
+.hero_image {
+  width: 100%;
+  max-width: 625px;
+  height: auto;
+  border-radius: 16px;
+  object-fit: cover;
 }
 .hero_btn {
   display: block;
@@ -22,4 +31,37 @@
 .hero_btn:hover {
   transform: scale(1.05);
   box-shadow: 0 8px 16px rgba(16, 24, 40, 0.2);
+}
+
+@media (max-width: 1024px) {
+  .home_wrapper {
+    gap: 48px;
+    margin: 20px 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .home_wrapper {
+    gap: 32px;
+    margin: 16px 0;
+    padding: 0 16px;
+  }
+
+  .hero_btn {
+    width: 100%;
+    text-align: center;
+    padding: 14px 24px;
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .home_wrapper {
+    gap: 24px;
+  }
+
+  .hero_btn {
+    font-size: 15px;
+    padding: 12px 20px;
+  }
 }


### PR DESCRIPTION
## Summary
- add responsive styling for the navigation and home hero to support small screens
- update catalog filters and card layouts so listings stack cleanly on mobile
- ensure favorites cards and the details modal adjust to handheld breakpoints

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d850a599bc83268ac48818a4655387