### PR TITLE
Add mobile filter drawer for catalog page

### DIFF
--- a/src/components/CardInfo/CardInfo.module.css
+++ b/src/components/CardInfo/CardInfo.module.css
@@ -161,3 +161,93 @@
   height: 100%;
   width: 888px;
 }
+
+@media (max-width: 1024px) {
+  .card_wrapper {
+    padding: 0 24px 32px;
+  }
+
+  .card_list_wrapper {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .card_wrapper {
+    padding: 0 16px 32px;
+    gap: 32px;
+    align-items: stretch;
+  }
+
+  .card_info {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 20px;
+    gap: 20px;
+  }
+
+  .card_img_wrapper {
+    width: 100%;
+    height: 220px;
+    border-radius: 14px;
+  }
+
+  .card_img {
+    border-radius: 14px;
+  }
+
+  .card_list_wrapper {
+    max-width: 100%;
+  }
+
+  .info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .left_info {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .description {
+    max-width: 100%;
+    margin-top: 16px;
+    -webkit-line-clamp: 3;
+  }
+
+  .list_details {
+    margin: 16px 0;
+    gap: 12px;
+  }
+
+  .item_details {
+    width: calc(50% - 6px);
+  }
+
+  .show_btn {
+    width: 100%;
+    padding: 14px 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .card_info {
+    padding: 16px;
+  }
+
+  .card_img_wrapper {
+    height: 200px;
+  }
+
+  .secondary_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .item_details {
+    width: 100%;
+  }
+}

--- a/src/components/Filter/Filter.jsx
+++ b/src/components/Filter/Filter.jsx
@@ -17,7 +17,7 @@ import wind_icon from '../../assets/icons/wind.svg';
 import location_icon from '../../assets/icons/location.svg';
 import location_disabled_icon from '../../assets/icons/location_disabled.svg';
 
-export const Filter = () => {
+export const Filter = ({ onSearchComplete }) => {
   const dispatch = useDispatch();
   const campers = useSelector(state => state.favorite.campers);
 
@@ -112,6 +112,9 @@ export const Filter = () => {
     }
 
     dispatch(setFilteredCampers(filteredResult));
+    if (typeof onSearchComplete === 'function') {
+      onSearchComplete();
+    }
   };
 
   return (

--- a/src/components/Filter/Filter.module.css
+++ b/src/components/Filter/Filter.module.css
@@ -187,3 +187,32 @@
 .equipment_list_item img {
   margin-bottom: 8px;
 }
+
+@media (max-width: 768px) {
+  .filter_container {
+    gap: 24px;
+  }
+
+  .location_container,
+  .equipment_wrapper,
+  .types_wrapper {
+    width: 100%;
+  }
+
+  .filters_wrapper {
+    gap: 24px;
+  }
+
+  .equipment_list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .types_list {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .search_btn {
+    align-self: stretch;
+  }
+}

--- a/src/pages/Catalog/Catalog.jsx
+++ b/src/pages/Catalog/Catalog.jsx
@@ -9,26 +9,81 @@ import styles from './Catalog.module.css';
 
 const Catalog = () => {
   const [loading, setLoading] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   useEffect(() => {
     setTimeout(() => {
-      setLoading(false); 
+      setLoading(false);
     }, 800);
   }, []);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  const handleOpenFilters = () => {
+    setIsFilterOpen(true);
+  };
+
+  const handleCloseFilters = () => {
+    setIsFilterOpen(false);
+  };
+
+  const handleFiltersApplied = () => {
+    if (isMobile) {
+      setIsFilterOpen(false);
+    }
+  };
+
   return (
-    <div>
-      <NavList/> 
+    <div className={styles.catalog_page}>
+      <NavList />
+      {isMobile && (
+        <button
+          type="button"
+          className={styles.mobile_search_button}
+          onClick={handleOpenFilters}
+          aria-haspopup="dialog"
+          aria-expanded={isFilterOpen}
+        >
+          Search
+        </button>
+      )}
+      {isMobile && isFilterOpen && (
+        <div className={styles.mobile_filters_overlay} role="dialog" aria-modal="true">
+          <div className={styles.mobile_filters_content}>
+            <button
+              type="button"
+              className={styles.mobile_filters_close}
+              aria-label="Close filters"
+              onClick={handleCloseFilters}
+            >
+              ×
+            </button>
+            <Filter onSearchComplete={handleFiltersApplied} />
+          </div>
+        </div>
+      )}
       {loading ? (
         <Loader />
       ) : (
-      <div className={styles.catalog_wrapper}>
-      <Filter/>
-      <CardInfo/>
-      </div>
-    )}
+        <div className={styles.catalog_wrapper}>
+          {!isMobile && <Filter />}
+          <CardInfo />
+        </div>
+      )}
     </div>
   );
 };
-  
+
 export default Catalog;

--- a/src/pages/Catalog/Catalog.module.css
+++ b/src/pages/Catalog/Catalog.module.css
@@ -1,7 +1,91 @@
+.catalog_page {
+  position: relative;
+  min-height: 100vh;
+}
+
 .catalog_wrapper {
   display: flex;
   gap: 64px;
   justify-content: center;
   margin-top: 24px;
   margin-bottom: 24px;
+}
+
+.mobile_search_button {
+  display: none;
+}
+
+.mobile_filters_overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(16, 24, 40, 0.4);
+  display: flex;
+  justify-content: flex-start;
+  align-items: stretch;
+  z-index: 1000;
+}
+
+.mobile_filters_content {
+  position: relative;
+  width: min(360px, 85%);
+  background: #ffffff;
+  padding: 24px 20px 32px;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(16, 24, 40, 0.15);
+}
+
+.mobile_filters_close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(16, 24, 40, 0.05);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: #101828;
+}
+
+.mobile_filters_close:hover {
+  background: rgba(16, 24, 40, 0.1);
+}
+
+@media (max-width: 1024px) {
+  .catalog_wrapper {
+    gap: 32px;
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .catalog_wrapper {
+    flex-direction: column;
+    gap: 24px;
+    margin-top: 16px;
+    padding: 0 16px 24px;
+  }
+
+  .mobile_search_button {
+    position: sticky;
+    top: 0;
+    left: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 8px 0 0 16px;
+    padding: 12px 20px;
+    border-radius: 9999px;
+    border: none;
+    font-weight: 600;
+    background: #e44848;
+    color: #f7f7f7;
+    box-shadow: 0 10px 20px rgba(16, 24, 40, 0.15);
+    z-index: 10;
+  }
 }


### PR DESCRIPTION
## Summary
- add mobile viewport detection in the catalog page and show a floating search button that opens filter controls in a modal drawer
- close the mobile drawer after search and keep the desktop layout unaffected
- add responsive styles so the filter form adapts to narrow screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d858f55a1083268f506eeb2d85ed54