### PR TITLE
Align mobile spacing across views

### DIFF
--- a/src/components/NavList/NavList.module.css
+++ b/src/components/NavList/NavList.module.css
@@ -1,3 +1,7 @@
+.nav_list_wrapper {
+  padding: 0 32px;
+}
+
 .navList {
   list-style: none;
   display: flex;
@@ -7,7 +11,7 @@
   font-weight: 500;
   gap: 60px;
   margin: 0;
-  padding: 20px 0 20px 20px;
+  padding: 20px 0;
 }
 
 .navItem {
@@ -33,4 +37,20 @@
 
 .navItem .activeLink {
   color: #e44848;
+}
+
+@media (max-width: 1024px) {
+  .nav_list_wrapper {
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav_list_wrapper {
+    padding: 0 16px;
+  }
+
+  .navList {
+    gap: 24px;
+  }
 }

--- a/src/pages/Catalog/Catalog.module.css
+++ b/src/pages/Catalog/Catalog.module.css
@@ -78,7 +78,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin: 8px 0 0 16px;
+    margin: 8px 16px 0;
     padding: 12px 20px;
     border-radius: 9999px;
     border: none;

--- a/src/pages/Favorites/Favorites.module.css
+++ b/src/pages/Favorites/Favorites.module.css
@@ -166,3 +166,88 @@
 .empty_template_title {
   font-size: 30px;
 }
+
+@media (max-width: 1024px) {
+  .favorites_container {
+    gap: 32px;
+    padding: 0 24px;
+  }
+
+  .card_list_wrapper {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .favorites_container {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 24px;
+    padding: 0 16px 32px;
+  }
+
+  .cards_wrapper {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .card_list_wrapper {
+    max-width: 100%;
+  }
+
+  .card_info {
+    flex-direction: column;
+    padding: 20px;
+    gap: 20px;
+  }
+
+  .card_img_wrapper {
+    width: 100%;
+    height: 220px;
+  }
+
+  .description {
+    max-width: 100%;
+    margin-top: 16px;
+  }
+
+  .list_details {
+    margin: 16px 0;
+    gap: 12px;
+  }
+
+  .item_details {
+    width: calc(50% - 6px);
+  }
+
+  .show_btn {
+    width: 100%;
+    padding: 14px 24px;
+  }
+
+  .empty_template {
+    left: 50%;
+    right: auto;
+    width: calc(100% - 32px);
+  }
+}
+
+@media (max-width: 480px) {
+  .card_info {
+    padding: 16px;
+  }
+
+  .card_img_wrapper {
+    height: 200px;
+  }
+
+  .secondary_info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .item_details {
+    width: 100%;
+  }
+}

--- a/src/pages/HomePage/HomePage.module.css
+++ b/src/pages/HomePage/HomePage.module.css
@@ -23,3 +23,26 @@
   transform: scale(1.05);
   box-shadow: 0 8px 16px rgba(16, 24, 40, 0.2);
 }
+
+@media (max-width: 1024px) {
+  .home_wrapper {
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .home_wrapper {
+    gap: 48px;
+    padding: 0 16px;
+  }
+
+  .home_wrapper img {
+    width: 100%;
+    height: auto;
+  }
+
+  .hero_btn {
+    width: 100%;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated navigation wrapper and responsive padding so mobile nav spacing is symmetrical
- update catalog search trigger and page layouts to keep horizontal gutters even on small screens
- refine favorites and home layouts for smaller widths, ensuring imagery and buttons respect the new gutters

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d85dccbc448326b95e6e1acd93ce35