### PR TITLE
Adjust mobile camper property layout

### DIFF
--- a/src/components/CardInfo/CardInfo.module.css
+++ b/src/components/CardInfo/CardInfo.module.css
@@ -106,6 +106,7 @@
   background: #f2f4f7;
   mix-blend-mode: multiply;
   text-transform: capitalize;
+  box-sizing: border-box;
 }
 
 .header_detail {

--- a/src/components/CardInfo/CardInfo.module.css
+++ b/src/components/CardInfo/CardInfo.module.css
@@ -233,6 +233,12 @@
 }
 
 @media (max-width: 480px) {
+  .list_details {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
   .card_info {
     padding: 16px;
   }
@@ -246,13 +252,7 @@
     align-items: flex-start;
     gap: 8px;
   }
-
-  .list_details {
-    gap: 10px;
-  }
-
   .item_details {
-    flex: 1 1 calc(50% - 5px);
-    width: calc(50% - 5px);
+    width: 100%;
   }
 }

--- a/src/components/CardInfo/CardInfo.module.css
+++ b/src/components/CardInfo/CardInfo.module.css
@@ -247,7 +247,12 @@
     gap: 8px;
   }
 
+  .list_details {
+    gap: 10px;
+  }
+
   .item_details {
-    width: 100%;
+    flex: 1 1 calc(50% - 5px);
+    width: calc(50% - 5px);
   }
 }


### PR DESCRIPTION
## Summary
- ensure camper property chips fit two per row on mobile viewports
- tweak spacing within the camper details list for small screens

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d85fe9e5388326b72c11ac4a2744ad