### PR TITLE
Align favorite cards with catalog styling

### DIFF
--- a/src/pages/Favorites/Favorites.jsx
+++ b/src/pages/Favorites/Favorites.jsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { ToastContainer, toast } from 'react-toastify';
 import { connect } from 'react-redux';
 
-import { setFavoriteCards ,removeFavoriteCard } from '../../redux/actions/actions';
+import { setFavoriteCards, removeFavoriteCard } from '../../redux/actions/actions';
 import { NavList } from '../../components/NavList/NavList';
 import { Loader } from '../../components/Loader/Loader';
 import { Modal } from '../../components/Modal/Modal';
@@ -19,6 +19,7 @@ import star_icon from '../../assets/icons/star.svg';
 import location_icon from '../../assets/icons/location.svg';
 
 import styles from './Favorites.module.css';
+import cardStyles from '../../components/CardInfo/CardInfo.module.css';
 
 const Favorites = ({ loading, error, favoriteCards }) => {
   const dispatch = useDispatch();
@@ -75,106 +76,98 @@ const Favorites = ({ loading, error, favoriteCards }) => {
         <div className={styles.favorites_container}>
           {loading && <Loader size={80} color="#00BFFF" />}
           {error && (
-            <div className={styles.Error}>
+            <div className={styles.error}>
               An error occurred: {error.message}
             </div>
           )}
           {!loading && !error && (
-            <div className={styles.cards_wrapper}>
+            <div className={cardStyles.card_wrapper}>
               {favoriteCards.map(
-                (camper, index) =>
+                camper =>
                   camper && (
-                    <div key={index} className={styles.FavoriteCard}>
-                      <ul key={camper._id} className={styles.card_list_wrapper}>
-                        <li className={styles.card_info}>
-                          <div className={styles.card_img_wrapper}>
-                            <img
-                              className={styles.card_img}
-                              src={camper.gallery[0]}
-                              alt={camper.name}
-                              width={290}
-                              height={310}
-                            />
-                          </div>
-                          <div>
-                            <div className={styles.info}>
-                              <h2>{camper.name}</h2>
-                              <div className={styles.left_info}>
-                                <h2>€{camper.price.toFixed(2)}</h2>
-                                <button
-                                  className={styles.like_btn}
-                                  onClick={() => handleLikeClick(camper)}
-                                >
-                                  <img src={heart_red_icon} alt="favorite icon" />
-                                </button>
-                              </div>
+                    <ul key={camper._id} className={cardStyles.card_list_wrapper}>
+                      <li className={cardStyles.card_info}>
+                        <div className={cardStyles.card_img_wrapper}>
+                          <img
+                            className={cardStyles.card_img}
+                            src={camper.gallery[0]}
+                            alt={camper.name}
+                            width={290}
+                            height={310}
+                          />
+                        </div>
+                        <div>
+                          <div className={cardStyles.info}>
+                            <h2>{camper.name}</h2>
+                            <div className={cardStyles.left_info}>
+                              <h2>€{camper.price.toFixed(2)}</h2>
+                              <button
+                                className={cardStyles.fav_btn}
+                                onClick={() => handleLikeClick(camper)}
+                              >
+                                <img src={heart_red_icon} alt="favorite icon" />
+                              </button>
                             </div>
-                            <div className={styles.secondary_info}>
-                              <div className={styles.rating_wrapper}>
-                                <img className={styles.star_icon} src={star_icon} alt="star icon" />
-                                {camper.rating}({camper.reviews.length} Reviews)
-                              </div>
-
-                              <div className={styles.flex_box}>
-                                <img className={styles.star_icon} src={location_icon} alt="star icon" />
-                                <span>{camper.location}</span>
-                              </div>
-                            </div>
-                            <p className={styles.description}>
-                              {camper.description}...
-                            </p>
-                            <ul className={styles.list_details}>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={persons_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.adults} adults
-                                </p>
-                              </li>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={transmission_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.transmission}
-                                </p>
-                              </li>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={fuel_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.engine}
-                                </p>
-                              </li>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={kitchen_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.details.kitchen && 'Kitchen'}
-                                </p>
-                              </li>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={bed_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.details.beds + ' beds'}
-                                </p>
-                              </li>
-                              <li className={styles.item_details}>
-                                <img className={styles.icons} src={wind_icon} alt="persons icon" />
-                                <p className={styles.header_detail}>
-                                  {camper.details.airConditioner > 0 && 'AC'}
-                                </p>
-                              </li>
-                            </ul>
-
-                            <button className={styles.show_btn} onClick={() => openModal(camper._id)}>
-                              Show more
-                            </button>
                           </div>
-                          {modalStates[camper._id] && (
-                            <Modal
-                              camper={camper}
-                              closeModal={() => closeModal(camper._id)}
-                            />
-                          )}
-                        </li>
-                      </ul>
-                    </div>
+                          <div className={cardStyles.secondary_info}>
+                            <div className={cardStyles.rating_wrapper}>
+                              <img className={cardStyles.star_icon} src={star_icon} alt="star icon" />
+                              {camper.rating}({camper.reviews.length} Reviews)
+                            </div>
+
+                            <div className={cardStyles.flex_box}>
+                              <img className={cardStyles.star_icon} src={location_icon} alt="star icon" />
+                              <span>{camper.location}</span>
+                            </div>
+                          </div>
+                          <p className={cardStyles.description}>{camper.description}...</p>
+                          <ul className={cardStyles.list_details}>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={persons_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>
+                                {camper.adults} adults
+                              </p>
+                            </li>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={transmission_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>{camper.transmission}</p>
+                            </li>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={fuel_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>{camper.engine}</p>
+                            </li>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={kitchen_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>
+                                {camper.details.kitchen && 'Kitchen'}
+                              </p>
+                            </li>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={bed_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>
+                                {camper.details.beds + ' beds'}
+                              </p>
+                            </li>
+                            <li className={cardStyles.item_details}>
+                              <img className={cardStyles.icons} src={wind_icon} alt="persons icon" />
+                              <p className={cardStyles.header_detail}>
+                                {camper.details.airConditioner > 0 && 'AC'}
+                              </p>
+                            </li>
+                          </ul>
+
+                          <button className={cardStyles.show_btn} onClick={() => openModal(camper._id)}>
+                            Show more
+                          </button>
+                        </div>
+                        {modalStates[camper._id] && (
+                          <Modal
+                            camper={camper}
+                            closeModal={() => closeModal(camper._id)}
+                          />
+                        )}
+                      </li>
+                    </ul>
                   )
               )}
             </div>

--- a/src/pages/Favorites/Favorites.module.css
+++ b/src/pages/Favorites/Favorites.module.css
@@ -2,142 +2,12 @@
   display: flex;
   gap: 64px;
   justify-content: center;
-  margin-top: 24px;
-  margin-bottom: 24px;
-}
-
-.cards_wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 50px;
-  align-items: center;
-}
-
-.card_list_wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  max-width: 888px;
-}
-
-.card_info {
-  display: flex;
-  padding: 24px;
-  align-items: flex-start;
-  gap: 24px;
-  border-radius: 20px;
-  border: 1px solid rgba(16, 24, 40, 0.2);
-  background: #fff;
-}
-
-.description {
-  display: -webkit-box;
-  max-width: 525px;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  overflow: hidden;
-  color: #475467;
-  line-height: 24px;
-  margin-top: 24px;
-}
-
-.card_img_wrapper {
-  width: 290px;
-  height: 310px;
-  overflow: hidden;
-}
-
-.card_img {
-  width: 100%;
-  height: 100%;
-  border-radius: 10px;
-  object-fit: cover;
-  object-position: center;
-}
-
-.info,
-.left_info {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-}
-
-.secondary_info {
-  display: flex;
-  justify-content: flex-start;
-  gap: 16px;
-  margin-top: 8px;
-}
-
-.like_btn {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.like_btn img {
-  width: 24px;
-  height: 24px;
-}
-
-.icons {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-}
-
-.show_btn {
-  width: auto;
-  padding: 16px 40px;
-  border-radius: 200px;
-  background: #e44848;
-  color: #f7f7f7;
-  font-weight: 500;
-  letter-spacing: -0.08px;
-  border: none;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.show_btn:hover {
-  transform: scale(1.05);
-  box-shadow: 0 8px 16px rgba(16, 24, 40, 0.2);
-}
-
-.item_details {
-  display: flex;
-  padding: 12px 18px;
-  align-items: center;
-  gap: 8px;
-  border-radius: 100px;
-  background: #f2f4f7;
-  mix-blend-mode: multiply;
-}
-
-.header_detail {
-  text-align: center;
-  font-weight: 500;
-  line-height: 20px;
-}
-
-.list_details {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-  align-content: center;
   margin: 24px 0;
 }
-.load_more_btn {
-  max-width: 150px;
-  background-color: transparent;
-  font-weight: 500;
-  letter-spacing: -0.08px;
-  padding: 16px 32px;
-  border-radius: 200px;
-  border: 1px solid rgba(16, 24, 40, 0.2);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+.error {
+  color: #e44848;
+  font-weight: 600;
 }
 
 .empty_template {
@@ -148,19 +18,7 @@
   font-size: 29px;
   font-weight: 700;
   color: #475467;
-}
-
-.star_icon {
-  margin-right: 4px;
-}
-
-.flex_box {
-  display: flex;
-  align-items: center;
-}
-
-.rating_wrapper {
-  border-bottom: 1px solid #101828;
+  text-align: center;
 }
 
 .empty_template_title {
@@ -172,10 +30,6 @@
     gap: 32px;
     padding: 0 24px;
   }
-
-  .card_list_wrapper {
-    width: 100%;
-  }
 }
 
 @media (max-width: 768px) {
@@ -184,70 +38,5 @@
     align-items: stretch;
     gap: 24px;
     padding: 0 16px 32px;
-  }
-
-  .cards_wrapper {
-    width: 100%;
-    align-items: stretch;
-  }
-
-  .card_list_wrapper {
-    max-width: 100%;
-  }
-
-  .card_info {
-    flex-direction: column;
-    padding: 20px;
-    gap: 20px;
-  }
-
-  .card_img_wrapper {
-    width: 100%;
-    height: 220px;
-  }
-
-  .description {
-    max-width: 100%;
-    margin-top: 16px;
-  }
-
-  .list_details {
-    margin: 16px 0;
-    gap: 12px;
-  }
-
-  .item_details {
-    width: calc(50% - 6px);
-  }
-
-  .show_btn {
-    width: 100%;
-    padding: 14px 24px;
-  }
-
-  .empty_template {
-    left: 50%;
-    right: auto;
-    width: calc(100% - 32px);
-  }
-}
-
-@media (max-width: 480px) {
-  .card_info {
-    padding: 16px;
-  }
-
-  .card_img_wrapper {
-    height: 200px;
-  }
-
-  .secondary_info {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
-  .item_details {
-    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- reuse the catalog card styling in the Favorites page by importing shared CardInfo styles
- streamline the Favorites layout styles and add a defined error state style to match catalog visuals

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d863d88fec8326b1ceadf185e96a15