### PR TITLE
Refocus campervan site on rentals

### DIFF
--- a/src/components/Filter/Filter.jsx
+++ b/src/components/Filter/Filter.jsx
@@ -26,6 +26,11 @@ export const Filter = ({ onSearchComplete }) => {
   const [cityFilter, setCityFilter] = useState('');
   const [equipmentFilters, setEquipmentFilters] = useState([]);
   const [selectedType, setSelectedType] = useState(null);
+  const [rentalStartDate, setRentalStartDate] = useState('');
+  const [rentalEndDate, setRentalEndDate] = useState('');
+  const [guestCount, setGuestCount] = useState('');
+  const [dateError, setDateError] = useState('');
+  const [guestError, setGuestError] = useState('');
 
   useEffect(() => {
     const fetchCampersData = async () => {
@@ -117,36 +122,101 @@ export const Filter = ({ onSearchComplete }) => {
     }
   };
 
+  const handleSearch = () => {
+    let hasError = false;
+
+    if (rentalStartDate && rentalEndDate && new Date(rentalStartDate) > new Date(rentalEndDate)) {
+      setDateError('Return date must be after the pick-up date.');
+      hasError = true;
+    } else {
+      setDateError('');
+    }
+
+    if (guestCount && Number(guestCount) < 1) {
+      setGuestError('At least one traveler is required.');
+      hasError = true;
+    } else {
+      setGuestError('');
+    }
+
+    if (!hasError) {
+      filterCampers();
+    }
+  };
+
   return (
     <div className={styles.filter_container}>
-      <div className={styles.location_container}>
-        <label className={styles.location_label} htmlFor="location_input">
-          Location{' '}
-        </label>
-        <div className={styles.relative_container}>
+      <div className={styles.rental_details_wrapper}>
+        <div className={styles.location_container}>
+          <label className={styles.location_label} htmlFor="location_input">
+            Pick-up location
+          </label>
+          <div className={styles.relative_container}>
+            <input
+              className={styles.location_input}
+              type="text"
+              id="location_input"
+              name="location"
+              placeholder="City"
+              required
+              onBlur={handleBlur}
+              onFocus={handleFocus}
+              onChange={(e) => setCityFilter(e.target.value)}
+            />
+            <img
+              className={styles.location_icon_disabled}
+              src={isInputFocused || inputValue ? location_icon : location_disabled_icon}
+              alt="location_icon"
+            />
+          </div>
+        </div>
+        <div className={styles.dates_wrapper}>
+          <p className={styles.section_label}>Rental dates</p>
+          <div className={styles.date_inputs}>
+            <label className={styles.visually_hidden} htmlFor="rental_start_date">Pick-up date</label>
+            <input
+              className={styles.date_input}
+              type="date"
+              id="rental_start_date"
+              name="rental_start_date"
+              value={rentalStartDate}
+              onChange={(e) => setRentalStartDate(e.target.value)}
+            />
+            <label className={styles.visually_hidden} htmlFor="rental_end_date">Return date</label>
+            <input
+              className={styles.date_input}
+              type="date"
+              id="rental_end_date"
+              name="rental_end_date"
+              min={rentalStartDate || undefined}
+              value={rentalEndDate}
+              onChange={(e) => setRentalEndDate(e.target.value)}
+            />
+          </div>
+          {dateError && <p className={styles.error_text}>{dateError}</p>}
+        </div>
+        <div className={styles.people_wrapper}>
+          <label className={styles.section_label} htmlFor="guests_count">
+            Travelers
+          </label>
           <input
-            className={styles.location_input}
-            type="text"
-            id="location_input"
-            name="location"
-            placeholder="Location"
-            required
-            onBlur={handleBlur}
-            onFocus={handleFocus}
-            onChange={(e) => setCityFilter(e.target.value)}
+            className={styles.number_input}
+            type="number"
+            id="guests_count"
+            name="guests_count"
+            min="1"
+            placeholder="Number of people"
+            value={guestCount}
+            onChange={(e) => setGuestCount(e.target.value)}
           />
-          <img
-            className={styles.location_icon_disabled}
-            src={isInputFocused || inputValue ? location_icon : location_disabled_icon}
-            alt="location_icon"
-          />
+          {guestError && <p className={styles.error_text}>{guestError}</p>}
         </div>
       </div>
       <div>
-        <p className={styles.filters_title}>Filters</p>
+        <p className={styles.filters_title}>Rental filters</p>
         <div className={styles.filters_wrapper}>
           <div className={styles.equipment_wrapper}>
-            <h2 className={styles.title}>Vehicle equipment</h2>
+            <h2 className={styles.title}>Campervan equipment</h2>
             <ul className={styles.equipment_list}>
               {equipment.map(({ id, name, icon, data }) => (
                 <li key={id} className={`${styles.equipment_list_item} ${equipmentFilters.includes(data) ? styles.checked : ''}`}>
@@ -172,7 +242,7 @@ export const Filter = ({ onSearchComplete }) => {
             </ul>
           </div>
           <div className={styles.types_wrapper}>
-            <h2 className={styles.title}>Vehicle type</h2>
+            <h2 className={styles.title}>Campervan type</h2>
             <ul className={styles.types_list}>
               {camperTypes.map((type) => (
                 <li 
@@ -191,7 +261,7 @@ export const Filter = ({ onSearchComplete }) => {
           </div>
         </div>
       </div>
-      <button onClick={filterCampers} className={styles.search_btn}>Search</button>
+      <button onClick={handleSearch} className={styles.search_btn}>Search</button>
     </div>
   );
 };

--- a/src/components/Filter/Filter.jsx
+++ b/src/components/Filter/Filter.jsx
@@ -5,6 +5,7 @@ import fetchCampers from '../../Api/ApiService';
 import { setFilteredCampers, startLoading, finishLoading, setCampers } from '../../redux/actions/actions';
 
 import styles from './Filter.module.css';
+import { MobileDateRangePicker } from './MobileDateRangePicker';
 
 import van_icon from '../../assets/icons/van.svg';
 import fully_integrated_icon from '../../assets/icons/fully_integrated.svg';
@@ -172,27 +173,14 @@ export const Filter = ({ onSearchComplete }) => {
         </div>
         <div className={styles.dates_wrapper}>
           <p className={styles.section_label}>Rental dates</p>
-          <div className={styles.date_inputs}>
-            <label className={styles.visually_hidden} htmlFor="rental_start_date">Pick-up date</label>
-            <input
-              className={styles.date_input}
-              type="date"
-              id="rental_start_date"
-              name="rental_start_date"
-              value={rentalStartDate}
-              onChange={(e) => setRentalStartDate(e.target.value)}
-            />
-            <label className={styles.visually_hidden} htmlFor="rental_end_date">Return date</label>
-            <input
-              className={styles.date_input}
-              type="date"
-              id="rental_end_date"
-              name="rental_end_date"
-              min={rentalStartDate || undefined}
-              value={rentalEndDate}
-              onChange={(e) => setRentalEndDate(e.target.value)}
-            />
-          </div>
+          <MobileDateRangePicker
+            startDate={rentalStartDate}
+            endDate={rentalEndDate}
+            onChange={({ startDate, endDate }) => {
+              setRentalStartDate(startDate);
+              setRentalEndDate(endDate);
+            }}
+          />
           {dateError && <p className={styles.error_text}>{dateError}</p>}
         </div>
         <div className={styles.people_wrapper}>

--- a/src/components/Filter/Filter.module.css
+++ b/src/components/Filter/Filter.module.css
@@ -62,20 +62,6 @@
   font-weight: 500;
 }
 
-.date_inputs {
-  display: flex;
-  gap: 8px;
-}
-
-.date_input {
-  width: 100%;
-  padding: 18px;
-  border-radius: 10px;
-  background: #f7f7f7;
-  border: none;
-  color: #101828;
-}
-
 .number_input {
   padding: 18px;
   border-radius: 10px;

--- a/src/components/Filter/Filter.module.css
+++ b/src/components/Filter/Filter.module.css
@@ -4,6 +4,12 @@
   gap: 32px;
 }
 
+.rental_details_wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .search_btn {
   width: 175px;
   padding: 16px 60px;
@@ -41,6 +47,68 @@
   flex-direction: column;
   gap: 8px;
   width: 360px;
+}
+
+.dates_wrapper,
+.people_wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 360px;
+}
+
+.section_label {
+  color: #475467;
+  font-weight: 500;
+}
+
+.date_inputs {
+  display: flex;
+  gap: 8px;
+}
+
+.date_input {
+  width: 100%;
+  padding: 18px;
+  border-radius: 10px;
+  background: #f7f7f7;
+  border: none;
+  color: #101828;
+}
+
+.number_input {
+  padding: 18px;
+  border-radius: 10px;
+  background: #f7f7f7;
+  border: none;
+  color: #101828;
+}
+
+.number_input::-webkit-outer-spin-button,
+.number_input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.number_input[type='number'] {
+  -moz-appearance: textfield;
+}
+
+.error_text {
+  color: #e44848;
+  font-size: 14px;
+}
+
+.visually_hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .location_label {
@@ -193,10 +261,20 @@
     gap: 24px;
   }
 
+  .rental_details_wrapper {
+    gap: 20px;
+  }
+
   .location_container,
+  .dates_wrapper,
+  .people_wrapper,
   .equipment_wrapper,
   .types_wrapper {
     width: 100%;
+  }
+
+  .date_inputs {
+    flex-direction: column;
   }
 
   .filters_wrapper {

--- a/src/components/Filter/MobileDateRangePicker.jsx
+++ b/src/components/Filter/MobileDateRangePicker.jsx
@@ -1,0 +1,308 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './MobileDateRangePicker.module.css';
+
+const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+const normalizeDate = date => {
+  const normalized = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+};
+
+const formatISODate = date => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const parseISODate = value => {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+};
+
+const isSameDay = (a, b) => a && b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const isBetweenExclusive = (target, start, end) => {
+  if (!start || !end) return false;
+  return target > start && target < end;
+};
+
+const addMonths = (date, count) => new Date(date.getFullYear(), date.getMonth() + count, 1);
+
+const getMonthMatrix = date => {
+  const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+  const firstWeekdayIndex = (firstDayOfMonth.getDay() + 6) % 7; // Monday start
+  const startDate = new Date(firstDayOfMonth);
+  startDate.setDate(startDate.getDate() - firstWeekdayIndex);
+
+  const weeks = [];
+  const currentDay = new Date(startDate);
+  for (let weekIndex = 0; weekIndex < 6; weekIndex += 1) {
+    const week = [];
+    for (let dayIndex = 0; dayIndex < 7; dayIndex += 1) {
+      week.push(new Date(currentDay));
+      currentDay.setDate(currentDay.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+
+  return weeks;
+};
+
+const formatDisplayDate = value => {
+  if (!value) {
+    return 'Add date';
+  }
+
+  const date = parseISODate(value);
+  if (!date) {
+    return 'Add date';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+};
+
+const formatSummaryDate = value => {
+  if (!value) {
+    return 'Add date';
+  }
+
+  const date = parseISODate(value);
+  if (!date) {
+    return 'Add date';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+};
+
+export const MobileDateRangePicker = ({ startDate, endDate, onChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftStart, setDraftStart] = useState(() => (startDate ? parseISODate(startDate) : null));
+  const [draftEnd, setDraftEnd] = useState(() => (endDate ? parseISODate(endDate) : null));
+
+  const today = useMemo(() => normalizeDate(new Date()), []);
+
+  useEffect(() => {
+    setDraftStart(startDate ? parseISODate(startDate) : null);
+  }, [startDate]);
+
+  useEffect(() => {
+    setDraftEnd(endDate ? parseISODate(endDate) : null);
+  }, [endDate]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  const months = useMemo(() => {
+    const baseMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    return Array.from({ length: 12 }).map((_, index) => {
+      const monthDate = addMonths(baseMonth, index);
+      return {
+        monthDate,
+        label: new Intl.DateTimeFormat('en-US', {
+          month: 'long',
+          year: 'numeric',
+        }).format(monthDate),
+        matrix: getMonthMatrix(monthDate),
+      };
+    });
+  }, [today]);
+
+  const handleDaySelect = day => {
+    const normalizedDay = normalizeDate(day);
+    if (normalizedDay < today) {
+      return;
+    }
+
+    if (!draftStart || (draftStart && draftEnd)) {
+      setDraftStart(normalizedDay);
+      setDraftEnd(null);
+      return;
+    }
+
+    if (isSameDay(normalizedDay, draftStart)) {
+      return;
+    }
+
+    if (normalizedDay < draftStart) {
+      setDraftStart(normalizedDay);
+      setDraftEnd(null);
+      return;
+    }
+
+    setDraftEnd(normalizedDay);
+  };
+
+  const handleApply = () => {
+    onChange({
+      startDate: draftStart ? formatISODate(draftStart) : '',
+      endDate: draftEnd ? formatISODate(draftEnd) : '',
+    });
+    setIsOpen(false);
+  };
+
+  const handleClear = () => {
+    setDraftStart(null);
+    setDraftEnd(null);
+    onChange({ startDate: '', endDate: '' });
+  };
+
+  const handleClose = () => {
+    setDraftStart(startDate ? parseISODate(startDate) : null);
+    setDraftEnd(endDate ? parseISODate(endDate) : null);
+    setIsOpen(false);
+  };
+
+  const nights = useMemo(() => {
+    if (!draftStart || !draftEnd) {
+      return 0;
+    }
+    const diff = draftEnd.getTime() - draftStart.getTime();
+    return Math.max(Math.round(diff / (1000 * 60 * 60 * 24)), 0);
+  }, [draftEnd, draftStart]);
+
+  const renderOverlay = () => (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Select travel dates">
+      <div className={styles.backdrop} onClick={handleClose} />
+      <div className={styles.sheet} role="presentation">
+        <div className={styles.sheet_header}>
+          <button
+            type="button"
+            className={styles.clear_button}
+            onClick={handleClear}
+            disabled={!draftStart && !draftEnd}
+          >
+            Clear
+          </button>
+          <p className={styles.sheet_title}>Select your travel dates</p>
+          <button type="button" className={styles.close_button} onClick={handleClose} aria-label="Close date picker">
+            ×
+          </button>
+        </div>
+        <div className={styles.summary_row}>
+          <div className={styles.summary_block}>
+            <span className={styles.summary_label}>Check-in</span>
+            <span className={styles.summary_value}>{formatSummaryDate(draftStart ? formatISODate(draftStart) : '')}</span>
+          </div>
+          <div className={styles.summary_block}>
+            <span className={styles.summary_label}>Check-out</span>
+            <span className={styles.summary_value}>{formatSummaryDate(draftEnd ? formatISODate(draftEnd) : '')}</span>
+          </div>
+        </div>
+        {nights > 0 && <p className={styles.nights_text}>{`${nights} night${nights > 1 ? 's' : ''}`}</p>}
+        <div className={styles.calendar_scroller}>
+          {months.map(month => (
+            <div key={month.label} className={styles.month_section}>
+              <p className={styles.month_label}>{month.label}</p>
+              <div className={styles.weekday_row}>
+                {WEEK_DAYS.map(dayName => (
+                  <span key={dayName} className={styles.weekday}>
+                    {dayName}
+                  </span>
+                ))}
+              </div>
+              {month.matrix.map((week, index) => (
+                <div key={`${month.label}-week-${index}`} className={styles.week_row}>
+                  {week.map(day => {
+                    const isFromCurrentMonth = day.getMonth() === month.monthDate.getMonth();
+                    const iso = formatISODate(day);
+                    const disabled = normalizeDate(day) < today || !isFromCurrentMonth;
+                    const selectedStart = draftStart && isSameDay(day, draftStart);
+                    const selectedEnd = draftEnd && isSameDay(day, draftEnd);
+                    const inRange = isBetweenExclusive(day, draftStart, draftEnd);
+
+                    const dayClasses = [styles.day_button];
+                    if (!isFromCurrentMonth) {
+                      dayClasses.push(styles.day_outside);
+                    }
+                    if (disabled) {
+                      dayClasses.push(styles.day_disabled);
+                    }
+                    if (selectedStart || selectedEnd) {
+                      dayClasses.push(styles.day_selected);
+                    }
+
+                    const cellClasses = [styles.day_cell];
+                    if (inRange) {
+                      cellClasses.push(styles.day_cell_in_range);
+                    }
+                    if (selectedStart && selectedEnd) {
+                      cellClasses.push(styles.day_cell_single);
+                    } else {
+                      if (selectedStart && draftEnd) {
+                        cellClasses.push(styles.day_cell_start);
+                      }
+                      if (selectedEnd && draftStart) {
+                        cellClasses.push(styles.day_cell_end);
+                      }
+                    }
+
+                    return (
+                      <div key={iso} className={cellClasses.join(' ')}>
+                        <button
+                          type="button"
+                          className={dayClasses.join(' ')}
+                          onClick={() => handleDaySelect(day)}
+                          disabled={disabled}
+                        >
+                          {day.getDate()}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          className={styles.apply_button}
+          onClick={handleApply}
+          disabled={!draftStart || !draftEnd}
+        >
+          Apply dates
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={styles.container}>
+      <button type="button" className={styles.trigger} onClick={() => setIsOpen(true)}>
+        <div className={styles.trigger_column}>
+          <span className={styles.trigger_label}>Check-in</span>
+          <span className={styles.trigger_value}>{formatDisplayDate(startDate)}</span>
+        </div>
+        <span className={styles.trigger_divider} aria-hidden="true" />
+        <div className={styles.trigger_column}>
+          <span className={styles.trigger_label}>Check-out</span>
+          <span className={styles.trigger_value}>{formatDisplayDate(endDate)}</span>
+        </div>
+      </button>
+      {isOpen && createPortal(renderOverlay(), document.body)}
+    </div>
+  );
+};
+

--- a/src/components/Filter/MobileDateRangePicker.module.css
+++ b/src/components/Filter/MobileDateRangePicker.module.css
@@ -1,0 +1,298 @@
+.container {
+  width: 100%;
+}
+
+.trigger {
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  border: none;
+  border-radius: 14px;
+  background: #f7f7f7;
+  padding: 12px 18px;
+  text-align: left;
+  cursor: pointer;
+  transition: box-shadow 0.3s ease;
+}
+
+.trigger:hover,
+.trigger:focus {
+  box-shadow: 0 0 0 2px rgba(228, 72, 72, 0.15);
+  outline: none;
+}
+
+.trigger_column {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 4px;
+}
+
+.trigger_label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.64px;
+  color: #475467;
+}
+
+.trigger_value {
+  font-size: 16px;
+  font-weight: 600;
+  color: #101828;
+}
+
+.trigger_divider {
+  width: 1px;
+  margin: 0 12px;
+  background: rgba(16, 24, 40, 0.12);
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(16, 24, 40, 0.45);
+}
+
+.sheet {
+  position: relative;
+  margin: 0 auto;
+  width: min(480px, 100%);
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: 24px 24px 0 0;
+  padding: 24px;
+  gap: 24px;
+  overflow: hidden;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.sheet_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sheet_title {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  color: #101828;
+}
+
+.clear_button,
+.close_button {
+  background: none;
+  border: none;
+  color: #1d2939;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.clear_button:disabled {
+  color: rgba(16, 24, 40, 0.35);
+  cursor: default;
+}
+
+.close_button {
+  font-size: 24px;
+  line-height: 1;
+  padding: 0 6px;
+}
+
+.summary_row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.summary_block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.summary_label {
+  font-size: 12px;
+  letter-spacing: 0.48px;
+  text-transform: uppercase;
+  color: #475467;
+}
+
+.summary_value {
+  font-size: 16px;
+  font-weight: 600;
+  color: #101828;
+}
+
+.nights_text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #475467;
+}
+
+.calendar_scroller {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 8px;
+  margin-right: -8px;
+}
+
+.month_section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.month_label {
+  font-weight: 600;
+  color: #101828;
+}
+
+.weekday_row,
+.week_row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.weekday {
+  font-size: 12px;
+  text-align: center;
+  color: #98a2b3;
+  padding-bottom: 8px;
+}
+
+.week_row {
+  gap: 0;
+}
+
+.day_cell {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.day_cell_in_range,
+.day_cell_start,
+.day_cell_end {
+  background: rgba(228, 72, 72, 0.12);
+}
+
+.day_cell_start {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+.day_cell_end {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
+.day_cell_single {
+  border-radius: 999px;
+  background: none !important;
+}
+
+.day_button {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: none;
+  font-weight: 500;
+  cursor: pointer;
+  color: #1d2939;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.day_button:hover:not(:disabled) {
+  background: rgba(228, 72, 72, 0.12);
+}
+
+.day_selected {
+  background: #e44848 !important;
+  color: #ffffff !important;
+}
+
+.day_outside {
+  color: rgba(152, 162, 179, 0.6);
+}
+
+.day_disabled {
+  color: rgba(152, 162, 179, 0.6);
+  cursor: not-allowed;
+}
+
+.apply_button {
+  width: 100%;
+  padding: 14px;
+  border-radius: 999px;
+  border: none;
+  background: #e44848;
+  color: #f7f7f7;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.apply_button:disabled {
+  background: rgba(228, 72, 72, 0.35);
+  cursor: default;
+  box-shadow: none;
+}
+
+.apply_button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(228, 72, 72, 0.25);
+}
+
+@media (max-width: 768px) {
+  .sheet {
+    border-radius: 20px 20px 0 0;
+    padding: 20px 16px 24px;
+  }
+
+  .trigger {
+    padding: 10px 14px;
+  }
+
+  .trigger_value {
+    font-size: 15px;
+  }
+
+  .summary_row {
+    gap: 12px;
+  }
+}
+

--- a/src/components/Filter/MobileDateRangePicker.module.css
+++ b/src/components/Filter/MobileDateRangePicker.module.css
@@ -55,6 +55,13 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  min-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  .overlay {
+    min-height: 100dvh;
+  }
 }
 
 .backdrop {
@@ -66,8 +73,9 @@
 .sheet {
   position: relative;
   margin: 0 auto;
-  width: min(480px, 100%);
-  max-height: 100%;
+  width: 100%;
+  max-width: 480px;
+  max-height: calc(100vh - 32px);
   display: flex;
   flex-direction: column;
   background: #ffffff;
@@ -76,6 +84,12 @@
   gap: 24px;
   overflow: hidden;
   animation: slideUp 0.3s ease;
+}
+
+@supports (height: 100dvh) {
+  .sheet {
+    max-height: calc(100dvh - 32px);
+  }
 }
 
 @keyframes slideUp {
@@ -160,6 +174,7 @@
   overflow-y: auto;
   padding-right: 8px;
   margin-right: -8px;
+  -webkit-overflow-scrolling: touch;
 }
 
 .month_section {
@@ -281,6 +296,7 @@
   .sheet {
     border-radius: 20px 20px 0 0;
     padding: 20px 16px 24px;
+    max-height: calc(100vh - 16px);
   }
 
   .trigger {
@@ -293,6 +309,14 @@
 
   .summary_row {
     gap: 12px;
+  }
+}
+
+@media (max-width: 768px) {
+  @supports (height: 100dvh) {
+    .sheet {
+      max-height: calc(100dvh - 16px);
+    }
   }
 }
 

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -9,10 +9,10 @@ const Home = () => {
     <div>
       <NavList/> 
         <div className={styles.home_wrapper}> 
-          <img src={camper_img} alt="Campers" width="625" height="222"/>
+          <img src={camper_img} alt="Campervan rentals" width="625" height="222"/>
           <div>
             <Link to="/catalog" className={styles.hero_btn}>
-              Buy a camper
+              Find a campervan to rent
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- retarget the homepage hero imagery and call-to-action toward renting campervans
- extend the catalog search with rental date pickers, traveler count input, and supporting validation
- add styling for the new rental details fields to keep the filter layout cohesive

## Testing
- CI=true npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68d86431f5408326a4b7141f4629b900